### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic-playwright.yml
+++ b/.github/workflows/chromatic-playwright.yml
@@ -3,7 +3,7 @@ name: Chromatic (Playwright)
 on: push
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
     chromatic-playwright:

--- a/.github/workflows/chromatic-playwright.yml
+++ b/.github/workflows/chromatic-playwright.yml
@@ -2,6 +2,9 @@ name: Chromatic (Playwright)
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
     chromatic-playwright:
         name: Run Chromatic (Playwright)


### PR DESCRIPTION
Potential fix for [https://github.com/stamped-principles/stamped-checklist/security/code-scanning/2](https://github.com/stamped-principles/stamped-checklist/security/code-scanning/2)

Add an explicit `permissions` block to the workflow file at the top level (recommended here since there is one job), with at least `contents: read`. This satisfies CodeQL’s requirement and preserves current functionality while enforcing least privilege for `GITHUB_TOKEN`.

**Best single fix for this file:**
- Edit `.github/workflows/chromatic-playwright.yml`
- Insert after `on: push`:
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
