### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic-storybook.yml
+++ b/.github/workflows/chromatic-storybook.yml
@@ -2,6 +2,9 @@ name: Chromatic (Storybook)
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
     chromatic:
         name: Run Chromatic (Storybook)

--- a/.github/workflows/chromatic-storybook.yml
+++ b/.github/workflows/chromatic-storybook.yml
@@ -3,7 +3,7 @@ name: Chromatic (Storybook)
 on: push
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
     chromatic:


### PR DESCRIPTION
Potential fix for [https://github.com/stamped-principles/stamped-checklist/security/code-scanning/1](https://github.com/stamped-principles/stamped-checklist/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for `actions/checkout` and does not change intended functionality.

Edit file **`.github/workflows/chromatic-storybook.yml`**, adding:

```yml
permissions:
  contents: read
```

directly under `on:` (or under `name:` before `on:`), so it applies to all jobs unless overridden.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
