### PR TITLE
Skip Chromatic workflows when triggered by Dependabot

### DIFF
--- a/.github/workflows/chromatic-playwright.yml
+++ b/.github/workflows/chromatic-playwright.yml
@@ -8,6 +8,9 @@ permissions:
 jobs:
     chromatic-playwright:
         name: Run Chromatic (Playwright)
+        # Dependabot-triggered runs cannot read Actions secrets, so the
+        # Chromatic project token is unavailable; skip instead of failing.
+        if: github.actor != 'dependabot[bot]'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/.github/workflows/chromatic-storybook.yml
+++ b/.github/workflows/chromatic-storybook.yml
@@ -8,6 +8,9 @@ permissions:
 jobs:
     chromatic:
         name: Run Chromatic (Storybook)
+        # Dependabot-triggered runs cannot read Actions secrets, so the
+        # Chromatic project token is unavailable; skip instead of failing.
+        if: github.actor != 'dependabot[bot]'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code


### PR DESCRIPTION
## Summary
Added conditional checks to skip Chromatic workflow runs when triggered by Dependabot, preventing failures due to unavailable Actions secrets.

## Key Changes
- Added `if: github.actor != 'dependabot[bot]'` condition to the `chromatic-playwright` workflow job
- Added `if: github.actor != 'dependabot[bot]'` condition to the `chromatic-storybook` workflow job
- Both conditions include explanatory comments noting that Dependabot-triggered runs cannot access Actions secrets, making the Chromatic project token unavailable

## Details
Dependabot pull requests run with restricted permissions and cannot access repository secrets by default. This change prevents the Chromatic jobs from attempting to run and failing when triggered by Dependabot, allowing the workflows to gracefully skip instead. This is a common pattern for handling third-party service integrations in CI/CD pipelines.

https://claude.ai/code/session_01LCeMUj6mWFiLaafPTpWqdM